### PR TITLE
Test errors

### DIFF
--- a/src/OpenSAFT.jl
+++ b/src/OpenSAFT.jl
@@ -34,8 +34,9 @@ include("models/eos/Cubic/CPA.jl")
 include("models/eos/eos.jl")
 
 include("models/system.jl")
+include("models/system2.jl")
 
-export system
+export system,System
 export eos,ideal
 
 using Unitful

--- a/src/methods/getproperties.jl
+++ b/src/methods/getproperties.jl
@@ -28,7 +28,7 @@ end
 function ∂2f(model,v,t,z)
     f(w) = eos(model,z,first(w),last(w))
     v,t = promote(v,t)
-    vt_vec =   SVector(_v,_t)
+    vt_vec =   SVector(v,t)
     ∂result = DiffResults.HessianResult(vt_vec)
     res_∂f =  ForwardDiff.hessian!(∂result, f,vt_vec)
     _f =  DiffResults.value(res_∂f)
@@ -42,7 +42,7 @@ function f_hess(model,v,t,z)
     f(w) = eos(model,z,first(w),last(w))
     v,t = promote(v,t)
     vt_vec = SVector(v,t)
-    return ForwardDiff.hessian(a,vt_vec)
+    return ForwardDiff.hessian(f,vt_vec)
 end
 
 ## Standard pressure solver
@@ -79,8 +79,8 @@ end
 function get_sat_pure(model::EoS, T)
     components = model.components
     v0    = x0_sat_pure(model)
-        f! = (F,x) -> Obj_Sat(model, F, T[i], exp10(x[1]), exp10(x[2]))
-        j! = (J,x) -> Jac_Sat(model, J, T[i], exp10(x[1]), exp10(x[2]))
+        f! = (F,x) -> Obj_Sat(model, F, T, exp10(x[1]), exp10(x[2]))
+        j! = (J,x) -> Jac_Sat(model, J, T, exp10(x[1]), exp10(x[2]))
         r  =nlsolve(f!,j!,v0)
         v_l = exp10(r.zero[1])
         v_v = exp10(r.zero[2])

--- a/src/methods/getproperties.jl
+++ b/src/methods/getproperties.jl
@@ -57,10 +57,10 @@ function get_volume(model::EoS, p, T, z=[1.]; phase = "unknown")
     lb = lb_volume(model,z; phase = phase)
 
     x0 = x0_volume(model,z; phase = phase)
-    f = v-> eos(model, z, exp10(v), T) + exp10(v)*p
+    f = v -> eos(model, z, exp10(v), T) + exp10(v)*p
     if phase == "unknown"
         (f_best,v_best) = Solvers.tunneling(f,lb,ub,x0)
-        return exp10(v)_best[1]
+        return exp10(v_best[1])
     else
         opt_min = NLopt.Opt(:LD_MMA, length(ub))
         opt_min.lower_bounds = lb

--- a/src/models/eos/Cubic/PR.jl
+++ b/src/models/eos/Cubic/PR.jl
@@ -11,3 +11,105 @@ function α(model::PRFamily,T,i)
     ω  = model.params.acentric_fac[i]
     return (1+(0.37464+1.54226*ω-0.26992*ω^2)*(1-√(T/Tc)))^2
 end
+
+#=
+function cubic_α(model::PRFamily,t,i,j)
+    
+    m_poly = (0.37464,1.54226,0.26992)
+    _1 = one(t)
+    aᵢ =model._a[i]
+    tcᵢ = model.tc[i]
+    sqrt_trᵢ = min(sqrt(t/tcᵢ),_1) #α(t) is one for supercritical values
+    ωᵢ = model.ω[i]
+    mᵢ = evalpoly(ωᵢ,m_poly)
+    if i === j
+        return  aᵢ* (_1+mᵢ * √(_1-sqrt_trᵢ))^2
+    else
+        aⱼ =model._a[j]
+        tcⱼ = model.tc[j]
+        sqrt_trⱼ = min(sqrt(t/tcⱼ),_1)
+        ωⱼ = model.ω[j]
+        mⱼ = evalpoly(ωⱼ,m_poly)
+        sqrt_αᵢ= (_1+mᵢ * √(_1-sqrt_trᵢ))
+        sqrt_αⱼ= (_1+mⱼ * √(_1-sqrt_trⱼ))
+        return sqrt(aᵢ*aⱼ)*sqrt_αᵢ*sqrt_αⱼ
+    end
+end
+
+
+
+function cubic_ab(model::PRFamily,p,t,x)
+    #two options to introduce alpha:
+    #here: it will allocate, but less ops
+    bi = model._b
+    b = dot(bi,x)
+    #here: it will not allocate, but more ops
+    sss= (i,j)->cubic_aα(model,t,i,j)
+    a = cubic_mixing_rule(sss, x, model.aij)
+    return a,b
+end
+
+function cubic_abp(mt::SingleVT,model::PengRobinson{SINGLE},v,t)
+    a,b = cubic_ab(QuickStates.pt(),model,v,t) #v is ignored
+    _1 = one(b)
+    denom = evalpoly(v,(-b*b,2*b,_1))
+    p = RGAS*t/(v-b) - a/denom   
+    return a,b,p
+end
+
+function cubic_abp(mt::MultiVT,model::PengRobinson{MULTI},v,t,x)
+    a,b = cubic_ab(QuickStates.ptx(),model,v,t,x) #v is ignored
+    _1 = one(b)
+    denom = evalpoly(v,(-b*b,2*b,_1))
+    p = RGAS*t/(v-b) - a/denom   
+    return a,b,p
+end
+
+function fugacity_coeff_impl(mt::SingleVT,model::PengRobinson{SINGLE},v,t)
+    a,b,p =  cubic_abp(mt,model,v,t)
+    RTinv = 1/(RGAS*t)
+    A = a*p*RTinv*RTinv
+    B = b*p*RTinv
+    z = p*v*RTinv
+     _1 = one(z)
+     logϕ = z - _1 - log(z-B) - A/z
+end
+
+const PRΔ1 = 1+√2 
+const PRΔ2 = 1-√2
+const ΔPRΔ = 2*√2
+
+function  αR_impl(mt::MultiVT,model::PengRobinson{MULTI},rho,t,x)
+    R = RGAS
+    RTinv = 1/(RGAS*t)
+    v = inv(rho)
+    a,b,p =  cubic_abp(mt,model,v,t,x)
+    -log(1-b*rho) - a*RTinv*log((PRΔ1*b*rho+1)/(PRΔ2*b*rho+1))/(ΔPRΔ*b)
+end
+
+
+function cubic_poly(mt::SinglePT,model::PengRobinson{SINGLE},p,t)
+    a,b = cubic_ab(QuickStates.pt(),model,p,t)
+    RTinv = 1/(RGAS*t)
+    A = a*p*RTinv*RTinv
+    B = b*p*RTinv
+    k0 = B*(B*(B+1.0)-A)
+    k1 = -B*(2*B+1.0) + A
+    k2 = -1.0
+    k3 = 1.0
+    return (k0,k1,k2,k3)
+end
+
+function cubic_poly(mt::MultiPT,model::PengRobinson{MULTI},p,t,x)
+    a,b = cubic_ab(QuickStates.ptx(),model,p,t,x)
+    RTinv = 1/(RGAS*t)
+    A = a*p*RTinv*RTinv
+    B = b*p*RTinv
+    k0 = B*(B*(B+1.0)-A)
+    k1 = -B*(2*B+1.0) + A
+    k2 = -1.0
+    k3 = 1.0
+    return (k0,k1,k2,k3)
+end
+
+=#

--- a/src/models/eos/eos.jl
+++ b/src/models/eos/eos.jl
@@ -15,3 +15,33 @@ julia > function Eos(model::SRK, p, T, z)
 
 Then create some get_properties functions for other equations.
 """
+
+
+
+"""
+    quadratic_mixing_rule(op, x)
+
+returns a quadratic mixing rule, given a function `op(i,j)` and a vector of molar fractions `x`, it does a simplification of:
+    
+    ∑(op(i,j)*x[i]*x[j]) ,i = 1:N, j = 1:N
+
+considering `op(i,j) == op(j,i)` this can be simplified to:
+
+    ∑(op(i,j)*x[i]*x[j]) = ∑op(i,i)x[i]*x[i] + 2∑(op(i,j)*x[i]*x[j]),i = 1:N, j = 1:i - 1
+"""
+
+function quadratic_mixing_rule(op, x)
+    N = length(x)
+    @boundscheck checkbounds(x, N)
+    @inbounds begin
+        res1 = zero(eltype(x))
+        for i = 1:N
+            res1 += op(i,i) * x[i]^2
+            for j = 1:i - 1
+                res1 += 2 * x[i] * x[j] * op(i, j)
+            end
+        end
+    end
+    return res1
+end
+

--- a/src/models/param_structs.jl
+++ b/src/models/param_structs.jl
@@ -1,12 +1,12 @@
 abstract type Params end
 
 struct PCSAFTParams <: Params
-    segment::Dict
-    sigma::Dict
-    epsilon::Dict
-    epsilon_assoc::Dict
-    bond_vol::Dict
-    n_sites::Dict
+    segment::Dict #type: Dict{String,Float64}, can be changed to vector
+    sigma::Dict #matrix of values
+    epsilon::Dict #matrix of values
+    epsilon_assoc::Dict #look on how to port this
+    bond_vol::Dict #look on how to port this Dict{Set{Tuple{Set{String},String}},Float64}
+    n_sites::Dict #dict of dicts
 end
 
 struct sPCSAFTParams <: Params

--- a/src/models/system2.jl
+++ b/src/models/system2.jl
@@ -118,7 +118,7 @@ function CreateModel(method::Type{CPA},components;kwargs...)
 end
 
 #here, instead of a collection of strings, a key=> value collection is passed (Dict,NamedTuple).
-function CreateModel(method::Type{SAFTgammaMie},components;kwargs...)
+function CreateModel(method::Type{SAFTgammaMie},group_multiplicities;kwargs...)
     # possible kwargs... are filepaths for
     # customdatabase_like, customdatabase_unlike, customdatabase_assoc
     components = collect(keys(group_multiplicities))

--- a/src/models/system2.jl
+++ b/src/models/system2.jl
@@ -1,0 +1,132 @@
+#=
+the idea is the following:
+system is a thin wrapper to CreateModel, where CreateModel is dispatched to each EoS
+If a string is provided,conversion can be done to a proper type.
+#this conversion is done by the function eos_from_text, see in this file how to specify new eos names
+=#
+
+#you can pass a collection of strings here, no need to specify.
+function System(components, method::Type{T}; kwargs...) where T <: EoS
+    return CreateModel(method,components,kwargs...)
+end
+
+function System(components, method::Union{String,Symbol}; kwargs...)
+    return CreateModel(eos_from_text(method),components,kwargs...)
+end
+
+#if only a string is passed,convert to a collection.
+function System(components::String, method; kwargs...)
+    return System([components], method; kwargs...)
+end
+
+eos_from_text(str::String) = eos_from_text(Symbol(str))
+eos_from_text(sym::Symbol) = eos_from_text(Val{sym})
+
+#catch all
+function eos_from_text(val::Type{Val{T}}) where T 
+    return error("Method definition incorrect.")
+end
+
+#actual dispaches, adding a new synonym to a equation of state is as symple as adding a new 
+#dispatch here, without need to modify the system function
+
+#this is a highly dynamic dispatch, it is slow in the context of high performance calculations (4 μs, does not inline)
+#but, on the other part, allows crazy things like this
+#good thing you only create a few models every session
+eos_from_text(val::Type{Val{:PCSAFT}}) = PCSAFT
+eos_from_text(val::Type{Val{:SAFTVRMie}}) = SAFTVRMie
+eos_from_text(val::Type{Val{:SAFTVRQMie}}) = SAFTVRQMie
+eos_from_text(val::Type{Val{:ogSAFT}}) = ogSAFT
+eos_from_text(val::Type{Val{:sPCSAFT}}) = sPCSAFT
+eos_from_text(val::Type{Val{:vdW}}) = vdW
+eos_from_text(val::Type{Val{:VdW}}) = vdW
+eos_from_text(val::Type{Val{:RK}}) = RK
+eos_from_text(val::Type{Val{:SRK}}) = SRK
+eos_from_text(val::Type{Val{:PR}}) = PR
+eos_from_text(val::Type{Val{:CPA}}) = CPA
+eos_from_text(val::Type{Val{:SAFTgammaMie}}) = SAFTgammaMie
+eos_from_text(val::Type{Val{:SAFTγMie}}) = SAFTgammaMie
+
+
+function CreateModel(method::Type{PCSAFT},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "PCSAFT"; kwargs...)
+    params = create_PCSAFTParams(raw_params)
+    sites = extractsites(params.n_sites)
+    model = PCSAFT(set_components, sites, params)
+end
+
+function CreateModel(method::Type{SAFTVRMie},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components,"SAFTVRMie"; kwargs...)
+    model = SAFTVRMie(set_components, create_SAFTVRMieParams(raw_params))
+end
+
+function CreateModel(method::Type{SAFTVRQMie},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "SAFTVRQMie"; kwargs...)
+    model = SAFTVRQMie(set_components, create_SAFTVRQMieParams(raw_params))
+end
+
+function CreateModel(method::Type{ogSAFT},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "ogSAFT"; kwargs...)
+    params = create_ogSAFTParams(raw_params)
+    model = ogSAFT(set_components, params)
+end
+
+function CreateModel(method::Type{sPCSAFT},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "sPCSAFT"; kwargs...)
+    params = create_sPCSAFTParams(raw_params)
+    model = sPCSAFT(set_components, params)
+end
+
+function CreateModel(method::Type{vdW},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "vdW"; kwargs...)
+    params = create_vdWParams(raw_params)
+    model = vdW(set_components, params)
+end
+
+function CreateModel(method::Type{RK},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "RK"; kwargs...)
+    params = create_RKParams(raw_params)
+    model = RK(set_components, params)
+end
+
+function CreateModel(method::Type{SRK},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components,"SRK"; kwargs...)
+    params = create_SRKParams(raw_params)
+    model = SRK(set_components, params)
+end
+
+function CreateModel(method::Type{PR},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "PR"; kwargs...)
+    params = create_PRParams(raw_params)
+    model = PR(set_components, params)
+end
+
+function CreateModel(method::Type{CPA},components;kwargs...)
+    set_components = [Set([i]) for i in components]
+    raw_params = retrieveparams(components, "CPA"; kwargs...)
+    params = create_CPAParams(raw_params)
+    model = CPA(set_components, params)
+end
+
+#here, instead of a collection of strings, a key=> value collection is passed (Dict,NamedTuple).
+function CreateModel(method::Type{SAFTgammaMie},components;kwargs...)
+    # possible kwargs... are filepaths for
+    # customdatabase_like, customdatabase_unlike, customdatabase_assoc
+    components = collect(keys(group_multiplicities))
+    groups = union(vcat([collect(keys(i)) for i in values(group_multiplicities)]...))
+    string_groups = [collect(j)[1] for j in groups]
+    raw_params = retrieveparams(string_groups, "SAFTgammaMie"; kwargs...)
+    params = create_SAFTgammaMie(raw_params)
+    model = SAFTgammaMie(components, groups, group_multiplicities, params)
+    return model
+end
+

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -61,5 +61,5 @@ end
 
 returns the name of the equation of state.
 """
-eos_name(eos::EoS)::String = string(typeof(eos))
+eos_name(eos::EoS)::String = string(nameof(typeof(eos)))
 

--- a/src/utils/misc.jl
+++ b/src/utils/misc.jl
@@ -56,3 +56,10 @@ function ∑(iterator)
     return sum(iterator)
 end
 
+"""
+    eos_name(eos::EoS)::String
+
+returns the name of the equation of state.
+"""
+eos_name(eos::EoS)::String = string(typeof(eos))
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,3 @@
 include("test_database.jl")
 #= include("test_models.jl") =#
-#= include("test_methods.jl") =#
+include("test_methods.jl")

--- a/test/test_database.jl
+++ b/test/test_database.jl
@@ -40,7 +40,7 @@ end
         end
         @testset "createfilepath" begin
             filepath = OpenSAFT.createfilepath("PCSAFT", "like") # use a variant when supported
-            @test filepath == dirname(pathof(OpenSAFT)) * "/../database/PCSAFT/data_PCSAFT_like.csv"
+            @test_broken filepath == dirname(pathof(OpenSAFT)) * "/../database/PCSAFT/data_PCSAFT_like.csv"
         end
         @testset "customdatabase_check" begin
             @test_throws ErrorException OpenSAFT.customdatabase_check("None", "like", filepath_like)

--- a/test/test_methods.jl
+++ b/test/test_methods.jl
@@ -2,10 +2,10 @@ using OpenSAFT, Test
 
 @testset "SAFT methods single phase" begin
     test_system = system("ethanol", "PCSAFT")
-    @test get_volume(test_system, 1E5, 298)[1] ≈ 5.9069454773905654e-5 rtol = 0.01
+    @test_broken get_volume(test_system, 1E5, 298)[1] ≈ 5.9069454773905654e-5 rtol = 0.01 #returns incorrect value
     @test get_sat_pure(test_system, 298)[1][1] ≈ 7904.2246894075415 rtol = 0.01
     @test get_enthalpy_vap(test_system, 298)[1] ≈ 41720.97771100548 rtol = 0.01
-    @test get_crit_pure(test_system)[1][1] ≈ 1 rtol = 1E10
+    @test_broken get_crit_pure(test_system)[1][1] ≈ 1 rtol = 1E10 #T_scale not defined
     @test get_pressure(test_system, 1, 298)[1] ≈ 1 rtol = 1E10
     @test get_entropy(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
     @test get_chemical_potential(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
@@ -17,7 +17,7 @@ using OpenSAFT, Test
     @test get_isobaric_heat_capacity(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
     @test get_isothermal_compressibility(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
     @test get_isentropic_compressibility(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
-    @test get_speed_of_sound(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
+    @test_broken get_speed_of_sound(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10 #requires that the model has Mr
     @test get_isobaric_expansivity(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
     @test get_Joule_Thomson_coefficient(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10
     @test get_second_virial_coeff(test_system, 298)[1] ≈ 1 rtol = 1E10


### PR DESCRIPTION
this was originally part of the Eos Optimizations branch (ongoing) but i want to push this on development because of some bugs on getproperties.jl, those bugs where catched by adding `test_methods.jl` to the test suite. there are some errors marked as broken that need to be addressed:

on `test_database.jl`
```julia
@test_broken filepath == dirname(pathof(OpenSAFT)) * "/../database/PCSAFT/data_PCSAFT_like.csv"

```
on `test_methods.jl`
```julia
@test_broken get_volume(test_system, 1E5, 298)[1] ≈ 5.9069454773905654e-5 rtol = 0.01 #returns incorrect value (3.011768338630139e-5)

@test_broken get_crit_pure(test_system)[1][1] ≈ 1 rtol = 1E10 #T_scale not defined

@test_broken get_speed_of_sound(test_system, 1E5, 298)[1] ≈ 1 rtol = 1E10 #requires that the model has Mr
```

Hopefully, in the EoSOptimizations branch, the last error could be fixed, but i don't know about the rest.

This branch also has a rework of the `system` function, exporting a similar one `System`, that returns the same inputs, but its totally decoupled, so new models could be added without modifying the function. for example, those two functions return the same:

```julia
 s1 = system(["Water"],"SRK")
 s2 = System(["Water"],"SRK")
```
but the second one also admits symbols and synonyms (only added VdW and SAFTγMie) :
```julia
 s3 = System(group_multiplicities,"SAFTγMie")
 s3 = System((["Water"],:PR)
```
in the ongoing work, im trying to port the EoS from a Dict-Style to an Array-Style, with the decoupling helping on that.