### PR TITLE
Minor fixes

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,5 +1,5 @@
-const N_A = 6.02214086e23 # mol-1
-const k_B = 1.38064852e-23 # m2 kg s-2 K-1
+const N_A = 6.02214076e23 # mol-1
+const k_B = 1.380649e-23 # m2 kg s-2 K-1
 const R̄   = N_A*k_B # m2 kg s-2 K-1 mol-1
-const ħ = 1.054571817e-34 # mol-1
-const h = 1.054571817e-34*2*π
+const ħ = 1.054571817e-34 # J s
+const h = 1.054571817e-34*2*π # J s

--- a/src/models/eos/SAFT/SAFTgammaMie.jl
+++ b/src/models/eos/SAFT/SAFTgammaMie.jl
@@ -275,7 +275,7 @@ function ϵ̄(model::SAFTgammaMieFamily, z, V, T, i, j)
     if i == j
         return @f(ϵ̄, i)
     else
-        return sqrt(@f(σ̄,i)*@f(σ̄,j))/@f(σ̄,i,j) * sqrt(@f(ϵ̄,i)*@f(ϵ̄,i))
+        return sqrt(@f(σ̄,i)*@f(σ̄,j))/@f(σ̄,i,j) * sqrt(@f(ϵ̄,i)*@f(ϵ̄,j))
     end
 end
 
@@ -436,7 +436,7 @@ function X(model::SAFTgammaMieFamily, z, V, T)
             error("X has failed to converge after $itermax iterations")
         end
         for i ∈ @comps, k ∈ @groups(i), a ∈ @sites(k)
-            rhs = (1+ρ*∑(x[j] * ∑(v[j][l] * ∑(n[l][b] * XDict[j,l,b] * @f(Δ,i,j,k,l,a,b) for b ∈ @sites(l)) for l ∈ @groups(j)) for j ∈ @comps))^-1
+            rhs = (1+ρ*∑(x[j] * ∑(v[j][l] * ∑(n[l][b] * XDict_old[j,l,b] * @f(Δ,i,j,k,l,a,b) for b ∈ @sites(l)) for l ∈ @groups(j)) for j ∈ @comps))^-1
             XDict[i,k,a] = (1-damping_factor)*XDict_old[i,k,a] + damping_factor*rhs
         end
         tol = sqrt(∑(∑(∑((XDict[i,k,a]-XDict_old[i,k,a])^2 for a ∈ @sites(k)) for k ∈ @groups(i)) for i ∈ @comps))


### PR DESCRIPTION
Hi there!  Nice work on this package!  I've had to adapt your code for a related project, and think I found two typos in the SAFT-gamma Mie implementation, as well as in the constants.  Not sure if you want to change them, if you're benchmarking against some other code with incorrect definitions as well, but wanted to give you a heads-up. :blush: There's a typo in `N_A`, and `k_B` was set to `1.380649e-23` by definition in 2019.